### PR TITLE
fix: totally scrolled check need consider value is rounded

### DIFF
--- a/src/console/index.ts
+++ b/src/console/index.ts
@@ -698,7 +698,7 @@ export default class Console extends Component<IOptions> {
     let isAtBottom = false
     if (scrollHeight === offsetHeight) {
       isAtBottom = true
-    } else if (scrollTop === scrollHeight - offsetHeight) {
+    } else if (Math.abs(scrollHeight - offsetHeight - scrollTop) < 1) {
       isAtBottom = true
     }
     this.isAtBottom = isAtBottom


### PR DESCRIPTION
according [MDN scrollHeight document](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#determine_if_an_element_has_been_totally_scrolled)

> scrollTop is a non-rounded number, while scrollHeight and clientHeight are rounded — so the only way to determine if the scroll area is scrolled to the bottom is by seeing if the scroll amount is close enough to some threshold (in this example 1):

to check an element has been totally scrolled should consider: scrollTop is a non-rounded number, while scrollHeight and clientHeight are rounded, so the consider should be like below:
> Math.abs(element.scrollHeight - element.clientHeight - element.scrollTop) < 1;
